### PR TITLE
Fix typo in major markdown page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 | vue use| 袁继伟 |
 | vue3/reactivity 源码  | 袁继伟 Pylon|
 | vue3/runtime-core 源码 | 袁继伟 |
-| HTPP2 | Pylon|
-| JS RunTime |
+| HTTP2 | Pylon|
+| JS Runtime |
 | severless |
 
 


### PR DESCRIPTION
I dont think have somthing call `htpp2` in real world..